### PR TITLE
[ Feat ] Patched Prompt

### DIFF
--- a/playground/tabbedscrollableselect.php
+++ b/playground/tabbedscrollableselect.php
@@ -10,7 +10,7 @@ $application = tabbedscrollableselect(
         [
             'id' => 0,
             'tab' => 'Jess Archer',
-            'body' => <<<BODY
+            'body' => <<<'BODY'
             Subject: Application for Software Developer Position - The Code to Success!
 
             Dear Hiring Manager,
@@ -31,7 +31,7 @@ $application = tabbedscrollableselect(
         [
             'id' => 1,
             'tab' => 'Joe Dixon',
-            'body' => <<<BODY
+            'body' => <<<'BODY'
             Subject: Innovative Applicant Alert: Ready to Engineer Success at [Company Name]!
 
             Dear Hiring Manager,
@@ -52,7 +52,7 @@ $application = tabbedscrollableselect(
         [
             'id' => 2,
             'tab' => 'Tim MacDonald',
-            'body' => <<<BODY
+            'body' => <<<'BODY'
             Subject: Ready to Commit: My Application for Software Developer at [Company Name]
 
             Dear Hiring Team,
@@ -73,7 +73,7 @@ $application = tabbedscrollableselect(
         [
             'id' => 3,
             'tab' => 'Mohammed Said',
-            'body' => <<<BODY
+            'body' => <<<'BODY'
             Subject: Coding My Way Into Your Team: Software Developer Application at [Company Name]
 
             Dear Hiring Manager,
@@ -94,7 +94,7 @@ $application = tabbedscrollableselect(
         [
             'id' => 4,
             'tab' => 'Nuno Maduro',
-            'body' => <<<BODY
+            'body' => <<<'BODY'
             Subject: Debugging Opportunities: Application for Software Developer at [Company Name]
 
             Dear Hiring Team,

--- a/src/Key.php
+++ b/src/Key.php
@@ -4,6 +4,4 @@ namespace ArtisanBuild\CommuniyPrompts;
 
 use Laravel\Prompts\Key as PromptsKey;
 
-class Key extends PromptsKey
-{
-}
+class Key extends PromptsKey {}

--- a/src/PatchedPrompt.php
+++ b/src/PatchedPrompt.php
@@ -68,6 +68,11 @@ abstract class PatchedPrompt
         static::setOutput(new BufferedConsoleOutput());
     }
 
+    /**
+     * Implentation for faked keypresses.
+     *
+     * @param array<int, string> $keys
+     */
     public static function fakeKeyPresses(array $keys, Closure $closure): void
     {
         foreach ($keys as $key) {

--- a/src/PatchedPrompt.php
+++ b/src/PatchedPrompt.php
@@ -3,22 +3,22 @@
 namespace ArtisanBuild\CommuniyPrompts;
 
 use ArtisanBuild\CommunityPrompts\Support\Nothing;
-use Laravel\Prompts\Output\BufferedConsoleOutput;
 use Closure;
+use Laravel\Prompts\Concerns;
 use Laravel\Prompts\Exceptions\FormRevertedException;
+use Laravel\Prompts\Output\BufferedConsoleOutput;
 use Laravel\Prompts\Output\ConsoleOutput;
+use Laravel\Prompts\Terminal;
 use RuntimeException;
 use Symfony\Component\Console\Output\OutputInterface;
 use Throwable;
-use Laravel\Prompts\Concerns;
-use Laravel\Prompts\Terminal;
 
 /**
  * PatchedPrompt
- * 
+ *
  * This abstract class is a temporary implementation to enable
  * support for AsyncPrompt until the referenced PR is merged.
- * 
+ *
  * @see https://github.com/laravel/prompts/pull/154
  */
 abstract class PatchedPrompt
@@ -219,7 +219,7 @@ abstract class PatchedPrompt
 
     public function runLoop(callable $callable): mixed
     {
-        while(($key = static::terminal()->read()) !== null) {
+        while (($key = static::terminal()->read()) !== null) {
             $result = $callable($key);
 
             if (! $this->is_nothing($result)) {

--- a/src/PatchedPrompt.php
+++ b/src/PatchedPrompt.php
@@ -1,0 +1,480 @@
+<?php
+
+namespace ArtisanBuild\CommuniyPrompts;
+
+use ArtisanBuild\CommunityPrompts\Support\Nothing;
+use Laravel\Prompts\Output\BufferedConsoleOutput;
+use Closure;
+use Laravel\Prompts\Exceptions\FormRevertedException;
+use Laravel\Prompts\Output\ConsoleOutput;
+use RuntimeException;
+use Symfony\Component\Console\Output\OutputInterface;
+use Throwable;
+use Laravel\Prompts\Concerns;
+use Laravel\Prompts\Terminal;
+
+/**
+ * PatchedPrompt
+ * 
+ * This abstract class is a temporary implementation to enable
+ * support for AsyncPrompt until the referenced PR is merged.
+ * 
+ * @see https://github.com/laravel/prompts/pull/154
+ */
+abstract class PatchedPrompt
+{
+    use Concerns\Colors;
+    use Concerns\Cursor;
+    use Concerns\Erase;
+    use Concerns\Events;
+    use Concerns\FakesInputOutput;
+    use Concerns\Fallback;
+    use Concerns\Interactivity;
+    use Concerns\Themes;
+
+    /**
+     * ================================================
+     * The following methods override the original methods from
+     * the FakesInputOutput trait with patched versions.
+     * ================================================
+     */
+
+    /**
+     * Fake the terminal and queue key presses to be simulated.
+     *
+     * @param  array<string>  $keys
+     */
+    public static function fake(array $keys = []): void
+    {
+        // Force interactive mode when testing because we will be mocking the terminal.
+        static::interactive();
+
+        $mock = \Mockery::mock(Terminal::class);
+
+        $mock->shouldReceive('write')->byDefault();
+        $mock->shouldReceive('exit')->byDefault();
+        $mock->shouldReceive('setTty')->byDefault();
+        $mock->shouldReceive('restoreTty')->byDefault();
+        $mock->shouldReceive('cols')->byDefault()->andReturn(80);
+        $mock->shouldReceive('lines')->byDefault()->andReturn(24);
+        $mock->shouldReceive('initDimensions')->byDefault();
+
+        static::fakeKeyPresses($keys, function (string $key) use ($mock) {
+            $mock->shouldReceive('read')->once()->andReturn($key);
+        });
+
+        static::$terminal = $mock;
+
+        static::setOutput(new BufferedConsoleOutput());
+    }
+
+    public static function fakeKeyPresses(array $keys, Closure $closure): void
+    {
+        foreach ($keys as $key) {
+            $closure($key);
+        }
+    }
+
+    /**
+     * ================================================
+     * The following properties are copied from the
+     * original Prompt class to ensure compatibility.
+     * ================================================
+     */
+
+    /**
+     * The current state of the prompt.
+     */
+    public string $state = 'initial';
+
+    /**
+     * The error message from the validator.
+     */
+    public string $error = '';
+
+    /**
+     * The cancel message displayed when this prompt is cancelled.
+     */
+    public string $cancelMessage = 'Cancelled.';
+
+    /**
+     * The previously rendered frame.
+     */
+    protected string $prevFrame = '';
+
+    /**
+     * How many new lines were written by the last output.
+     */
+    protected int $newLinesWritten = 1;
+
+    /**
+     * Whether user input is required.
+     */
+    public bool|string $required;
+
+    /**
+     * The validator callback or rules.
+     */
+    public mixed $validate;
+
+    /**
+     * The cancellation callback.
+     */
+    protected static ?Closure $cancelUsing;
+
+    /**
+     * Indicates if the prompt has been validated.
+     */
+    protected bool $validated = false;
+
+    /**
+     * The custom validation callback.
+     */
+    protected static ?Closure $validateUsing;
+
+    /**
+     * The revert handler from the StepBuilder.
+     */
+    protected static ?Closure $revertUsing = null;
+
+    /**
+     * The output instance.
+     */
+    protected static OutputInterface $output;
+
+    /**
+     * The terminal instance.
+     */
+    protected static Terminal $terminal;
+
+    /**
+     * Get the value of the prompt.
+     */
+    abstract public function value(): mixed;
+
+    /**
+     * Render the prompt and listen for input.
+     */
+    public function prompt(): mixed
+    {
+        try {
+            $this->capturePreviousNewLines();
+
+            if (static::shouldFallback()) {
+                return $this->fallback();
+            }
+
+            static::$interactive ??= stream_isatty(STDIN);
+
+            if (! static::$interactive) {
+                return $this->default();
+            }
+
+            $this->checkEnvironment();
+
+            try {
+                static::terminal()->setTty('-icanon -isig -echo');
+            } catch (Throwable $e) {
+                static::output()->writeln("<comment>{$e->getMessage()}</comment>");
+                static::fallbackWhen(true);
+
+                return $this->fallback();
+            }
+
+            $this->hideCursor();
+            $this->render();
+
+            $result = $this->runLoop(function (string $key): mixed {
+                $continue = $this->handleKeyPress($key);
+
+                $this->render();
+
+                if ($continue === false || $key === Key::CTRL_C) {
+                    if ($key === Key::CTRL_C) {
+                        if (isset(static::$cancelUsing)) {
+                            return (static::$cancelUsing)();
+                        } else {
+                            static::terminal()->exit();
+                        }
+                    }
+
+                    if ($key === Key::CTRL_U && self::$revertUsing) {
+                        throw new FormRevertedException();
+                    }
+
+                    return $this->value();
+                }
+
+                // `null` is a valid return value for this loop
+                // so we'll return an instance of Nothing to
+                // indicate that the loop should continue.
+                return new Nothing;
+            });
+
+            return $result;
+        } finally {
+            $this->clearListeners();
+        }
+    }
+
+    public function runLoop(callable $callable): mixed
+    {
+        while(($key = static::terminal()->read()) !== null) {
+            $result = $callable($key);
+
+            if (! $this->is_nothing($result)) {
+                return $result;
+            }
+        }
+    }
+
+    /**
+     * Check if the provided item is an instance of Nothing.
+     */
+    public function is_nothing(mixed $item): bool
+    {
+        return is_object($item) && is_a($item, Nothing::class);
+    }
+
+    /**
+     * Register a callback to be invoked when a user cancels a prompt.
+     */
+    public static function cancelUsing(?Closure $callback): void
+    {
+        static::$cancelUsing = $callback;
+    }
+
+    /**
+     * How many new lines were written by the last output.
+     */
+    public function newLinesWritten(): int
+    {
+        return $this->newLinesWritten;
+    }
+
+    /**
+     * Capture the number of new lines written by the last output.
+     */
+    protected function capturePreviousNewLines(): void
+    {
+        $this->newLinesWritten = method_exists(static::output(), 'newLinesWritten')
+            ? static::output()->newLinesWritten()
+            : 1;
+    }
+
+    /**
+     * Set the output instance.
+     */
+    public static function setOutput(OutputInterface $output): void
+    {
+        static::$output = $output;
+    }
+
+    /**
+     * Get the current output instance.
+     */
+    protected static function output(): OutputInterface
+    {
+        return static::$output ??= new ConsoleOutput();
+    }
+
+    /**
+     * Write output directly, bypassing newline capture.
+     */
+    protected static function writeDirectly(string $message): void
+    {
+        match (true) {
+            method_exists(static::output(), 'writeDirectly') => static::output()->writeDirectly($message),
+            method_exists(static::output(), 'getOutput') => static::output()->getOutput()->write($message),
+            default => static::output()->write($message),
+        };
+    }
+
+    /**
+     * Get the terminal instance.
+     */
+    public static function terminal(): Terminal
+    {
+        return static::$terminal ??= new Terminal();
+    }
+
+    /**
+     * Set the custom validation callback.
+     */
+    public static function validateUsing(Closure $callback): void
+    {
+        static::$validateUsing = $callback;
+    }
+
+    /**
+     * Revert the prompt using the given callback.
+     *
+     * @internal
+     */
+    public static function revertUsing(Closure $callback): void
+    {
+        static::$revertUsing = $callback;
+    }
+
+    /**
+     * Clear any previous revert callback.
+     *
+     * @internal
+     */
+    public static function preventReverting(): void
+    {
+        static::$revertUsing = null;
+    }
+
+    /**
+     * Render the prompt.
+     */
+    protected function render(): void
+    {
+        $this->terminal()->initDimensions();
+
+        $frame = $this->renderTheme();
+
+        if ($frame === $this->prevFrame) {
+            return;
+        }
+
+        if ($this->state === 'initial') {
+            static::output()->write($frame);
+
+            $this->state = 'active';
+            $this->prevFrame = $frame;
+
+            return;
+        }
+
+        $terminalHeight = $this->terminal()->lines();
+        $previousFrameHeight = count(explode(PHP_EOL, $this->prevFrame));
+        $renderableLines = array_slice(explode(PHP_EOL, $frame), abs(min(0, $terminalHeight - $previousFrameHeight)));
+
+        $this->moveCursorToColumn(1);
+        $this->moveCursorUp(min($terminalHeight, $previousFrameHeight) - 1);
+        $this->eraseDown();
+        $this->output()->write(implode(PHP_EOL, $renderableLines));
+
+        $this->prevFrame = $frame;
+    }
+
+    /**
+     * Submit the prompt.
+     */
+    protected function submit(): void
+    {
+        $this->validate($this->value());
+
+        if ($this->state !== 'error') {
+            $this->state = 'submit';
+        }
+    }
+
+    /**
+     * Handle a key press and determine whether to continue.
+     */
+    private function handleKeyPress(string $key): bool
+    {
+        if ($this->state === 'error') {
+            $this->state = 'active';
+        }
+
+        $this->emit('key', $key);
+
+        if ($this->state === 'submit') {
+            return false;
+        }
+
+        if ($key === Key::CTRL_U) {
+            if (! self::$revertUsing) {
+                $this->state = 'error';
+                $this->error = 'This cannot be reverted.';
+
+                return true;
+            }
+
+            $this->state = 'cancel';
+            $this->cancelMessage = 'Reverted.';
+
+            call_user_func(self::$revertUsing);
+
+            return false;
+        }
+
+        if ($key === Key::CTRL_C) {
+            $this->state = 'cancel';
+
+            return false;
+        }
+
+        if ($this->validated) {
+            $this->validate($this->value());
+        }
+
+        return true;
+    }
+
+    /**
+     * Validate the input.
+     */
+    private function validate(mixed $value): void
+    {
+        $this->validated = true;
+
+        if ($this->required !== false && $this->isInvalidWhenRequired($value)) {
+            $this->state = 'error';
+            $this->error = is_string($this->required) && strlen($this->required) > 0 ? $this->required : 'Required.';
+
+            return;
+        }
+
+        if (! isset($this->validate) && ! isset(static::$validateUsing)) {
+            return;
+        }
+
+        $error = match (true) {
+            is_callable($this->validate) => ($this->validate)($value),
+            isset(static::$validateUsing) => (static::$validateUsing)($this),
+            default => throw new RuntimeException('The validation logic is missing.'),
+        };
+
+        if (! is_string($error) && ! is_null($error)) {
+            throw new RuntimeException('The validator must return a string or null.');
+        }
+
+        if (is_string($error) && strlen($error) > 0) {
+            $this->state = 'error';
+            $this->error = $error;
+        }
+    }
+
+    /**
+     * Determine whether the given value is invalid when the prompt is required.
+     */
+    protected function isInvalidWhenRequired(mixed $value): bool
+    {
+        return $value === '' || $value === [] || $value === false || $value === null;
+    }
+
+    /**
+     * Check whether the environment can support the prompt.
+     */
+    private function checkEnvironment(): void
+    {
+        if (PHP_OS_FAMILY === 'Windows') {
+            throw new RuntimeException('Prompts is not currently supported on Windows. Please use WSL or configure a fallback.');
+        }
+    }
+
+    /**
+     * Restore the cursor and terminal state.
+     */
+    public function __destruct()
+    {
+        $this->restoreCursor();
+
+        static::terminal()->restoreTty();
+    }
+}

--- a/src/PatchedPrompt.php
+++ b/src/PatchedPrompt.php
@@ -71,7 +71,7 @@ abstract class PatchedPrompt
     /**
      * Implentation for faked keypresses.
      *
-     * @param array<int, string> $keys
+     * @param  array<int, string>  $keys
      */
     public static function fakeKeyPresses(array $keys, Closure $closure): void
     {

--- a/src/Support/Nothing.php
+++ b/src/Support/Nothing.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace ArtisanBuild\CommunityPrompts\Support;
+
+/**
+ * Nothing.
+ * 
+ * `null` is a valid return value, so we use `Nothing`
+ * to indicate that a given loop should continue.
+ * 
+ * @see https://github.com/laravel/prompts/pull/154
+ */
+class Nothing
+{
+    //
+}

--- a/src/Support/Nothing.php
+++ b/src/Support/Nothing.php
@@ -4,10 +4,10 @@ namespace ArtisanBuild\CommunityPrompts\Support;
 
 /**
  * Nothing.
- * 
+ *
  * `null` is a valid return value, so we use `Nothing`
  * to indicate that a given loop should continue.
- * 
+ *
  * @see https://github.com/laravel/prompts/pull/154
  */
 class Nothing

--- a/src/TabbedScrollableSelectPrompt.php
+++ b/src/TabbedScrollableSelectPrompt.php
@@ -4,9 +4,9 @@ namespace ArtisanBuild\CommunityPrompts;
 
 use ArtisanBuild\CommunityPrompts\Themes\Default\TabbedScrollableSelectRenderer;
 use Closure;
+use Illuminate\Support\Collection;
 use Laravel\Prompts\Key;
 use Laravel\Prompts\Prompt;
-use Illuminate\Support\Collection;
 
 /**
  * @phpstan-type TOption = array{id: int|string, tab: string, body: string}
@@ -16,7 +16,7 @@ class TabbedScrollableSelectPrompt extends Prompt
     /**
      * Index of the currently selected option.
      */
-    public int|null $selected;
+    public ?int $selected;
 
     public int $firstVisible = 0;
 
@@ -24,7 +24,7 @@ class TabbedScrollableSelectPrompt extends Prompt
 
     /**
      * The processed content for the tabbed-scrollable-select prompt.
-     * 
+     *
      * @var Collection<int, Collection<int, string>>
      */
     public readonly Collection $content;
@@ -38,9 +38,9 @@ class TabbedScrollableSelectPrompt extends Prompt
 
     /**
      * Create a new TabbedScrollableSelectPrompt instance.
-     * 
+     *
      * @param  array<int, TOption>|Collection<int, TOption>  $options
-     * @param int|Closure(Collection<int, TOption>): Collection<int, TOption> $default The default value for the prompt. If Closure, it is passed `$options` and should return a Collection containing only the desired record.
+     * @param  int|Closure(Collection<int, TOption>): Collection<int, TOption>  $default  The default value for the prompt. If Closure, it is passed `$options` and should return a Collection containing only the desired record.
      */
     public function __construct(
         public string $label,
@@ -64,7 +64,7 @@ class TabbedScrollableSelectPrompt extends Prompt
             return $this->processContentBody((string) $option['body'], $this->width);
         });
 
-        $this->on('key', fn ($key) => match($key) {
+        $this->on('key', fn ($key) => match ($key) {
             Key::ENTER => $this->submit(),
             Key::ESCAPE => $this->handleEscape(),
             Key::UP, Key::UP_ARROW => $this->handleUpArrow(),
@@ -131,7 +131,9 @@ class TabbedScrollableSelectPrompt extends Prompt
 
     protected function doTimes(int $times, Closure $closure): void
     {
-        for ($i = 0; $i < $times; $i++) $closure();
+        for ($i = 0; $i < $times; $i++) {
+            $closure();
+        }
     }
 
     protected function handleUpArrow(): void

--- a/src/Themes/Default/Concerns/DrawsTabs.php
+++ b/src/Themes/Default/Concerns/DrawsTabs.php
@@ -12,7 +12,7 @@ trait DrawsTabs
     /**
      * Render a row of tabs.
      *
-     * @param Collection<int, string>  $tabs
+     * @param  Collection<int, string>  $tabs
      */
     protected function tabs(
         Collection $tabs,
@@ -25,15 +25,15 @@ trait DrawsTabs
         // Build the top row for the tabs by adding whitespace equal
         // to the width of each tab plus padding, or by adding an
         // equal number of box characters for the selected tab.
-        $top_row = $tabs->map(fn($value, $key) => $key === $selected
-            ? '╭' . str_repeat('─', $strippedWidth($value) + 2) . '╮'
+        $top_row = $tabs->map(fn ($value, $key) => $key === $selected
+            ? '╭'.str_repeat('─', $strippedWidth($value) + 2).'╮'
             : str_repeat(' ', $strippedWidth($value) + 4)
         )->implode('');
 
         // Build the middle row for the tabs by adding the tab name
         // surrounded by some padding. But if the tab is selected
         // then highlight the tab and surround it in box chars.
-        $middle_row = $tabs->map(fn($value, $key) => $key === $selected
+        $middle_row = $tabs->map(fn ($value, $key) => $key === $selected
             ? "{$this->dim('│')} {$this->{$color}($value)} {$this->dim('│')}"
             : "  {$value}  "
         )->implode('');
@@ -41,8 +41,8 @@ trait DrawsTabs
         // Build the bottom row for the tabs by adding box characters equal to the width
         // of each tab, plus padding. If the tab is selected, add the appropriate box
         // characters instead. Finally, pad the whole line to fill the width fully.
-        $bottom_row = $tabs->map(fn($value, $key) => $key === $selected
-            ? '┴' . str_repeat('─', $strippedWidth($value) + 2) . '┴'
+        $bottom_row = $tabs->map(fn ($value, $key) => $key === $selected
+            ? '┴'.str_repeat('─', $strippedWidth($value) + 2).'┴'
             : str_repeat('─', $strippedWidth($value) + 4)
         )->implode('');
         $bottom_row = $this->pad($bottom_row, $width, '─');

--- a/src/Themes/Default/TabbedScrollableSelectRenderer.php
+++ b/src/Themes/Default/TabbedScrollableSelectRenderer.php
@@ -2,18 +2,18 @@
 
 namespace ArtisanBuild\CommunityPrompts\Themes\Default;
 
+use ArtisanBuild\CommunityPrompts\TabbedScrollableSelectPrompt;
 use Illuminate\Support\Collection;
-use Laravel\Prompts\Themes\Default\Renderer;
 use Laravel\Prompts\Themes\Contracts\Scrolling;
 use Laravel\Prompts\Themes\Default\Concerns\DrawsBoxes;
 use Laravel\Prompts\Themes\Default\Concerns\DrawsScrollbars;
-use ArtisanBuild\CommunityPrompts\TabbedScrollableSelectPrompt;
+use Laravel\Prompts\Themes\Default\Renderer;
 
 class TabbedScrollableSelectRenderer extends Renderer implements Scrolling
 {
+    use Concerns\DrawsTabs;
     use DrawsBoxes;
     use DrawsScrollbars;
-    use Concerns\DrawsTabs;
 
     /**
      * Render the tabbed-scrollable-select prompt.
@@ -53,7 +53,7 @@ class TabbedScrollableSelectRenderer extends Renderer implements Scrolling
                 )
                 ->when(
                     true,
-                    fn () => $this->renderInstructions($prompt)->each(fn($line) => $this->hint($line)),
+                    fn () => $this->renderInstructions($prompt)->each(fn ($line) => $this->hint($line)),
                     fn () => $this->newLine() // Space for errors
                 ),
         };
@@ -97,13 +97,13 @@ class TabbedScrollableSelectRenderer extends Renderer implements Scrolling
 
     /**
      * Render the instructions.
-     * 
+     *
      * @return \Illuminate\Support\Collection<int, string>
      */
     protected function renderInstructions(TabbedScrollableSelectPrompt $prompt): Collection
     {
         return $prompt->getInstructions()
-            ->map(fn($line) => $this->dim($line));
+            ->map(fn ($line) => $this->dim($line));
     }
 
     /**

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -4,15 +4,14 @@ namespace ArtisanBuild\CommunityPrompts;
 
 use Closure;
 use Illuminate\Support\Collection;
-use ArtisanBuild\CommunityPrompts\TabbedScrollableSelectPrompt;
 
 /**
  * Prompt the user to select an option from a scrollable tabbed list.
- * 
+ *
  * @template TOption of array{id: int|string, tab: string, body: string}
- * 
+ *
  * @param  array<int, TOption>|Collection<int, TOption>  $options
- * @param  int|Closure(Collection<int, TOption>): Collection<int, TOption> $default The default value for the prompt. If Closure, it is passed `$options` and should return a Collection containing only the desired record.
+ * @param  int|Closure(Collection<int, TOption>): Collection<int, TOption>  $default  The default value for the prompt. If Closure, it is passed `$options` and should return a Collection containing only the desired record.
  */
 function tabbedscrollableselect(string $label, array|Collection $options, int|Closure $default = 0, int $scroll = 14, int $max_width = 120, bool|string $required = true, mixed $validate = null, string $hint = ''): int|string|null
 {

--- a/tests/Feature/DrawsTabsTest.php
+++ b/tests/Feature/DrawsTabsTest.php
@@ -1,8 +1,8 @@
 <?php
 
+use ArtisanBuild\CommunityPrompts\Themes\Default\Concerns\DrawsTabs;
 use Illuminate\Support\Collection;
 use Laravel\Prompts\Prompt;
-use ArtisanBuild\CommunityPrompts\Themes\Default\Concerns\DrawsTabs;
 use Laravel\Prompts\Themes\Default\Renderer;
 
 class TestPrompt extends Prompt
@@ -41,10 +41,9 @@ class TestRenderer extends Renderer
  * Removing it will cause the test to fail (correctly) while allowing
  * the output to appear indistinguishable from the expected output.
  */
-
 it('renders tabs', function () {
     Prompt::fake();
-    
+
     $tabs = collect(['One', 'Two', 'Three', 'Four', 'Five', 'Six']);
 
     (new TestPrompt($tabs))->display();
@@ -72,7 +71,7 @@ it('highlights tabs', function () {
 
 it('truncates tabs', function () {
     Prompt::fake();
-    
+
     $tabs = collect(['One', 'Two', 'Three', 'Four', 'Five', 'Six', 'Seven', 'Eight']);
 
     (new TestPrompt($tabs))->display();

--- a/tests/Feature/TabbedScrollableSelectPromptTest.php
+++ b/tests/Feature/TabbedScrollableSelectPromptTest.php
@@ -26,7 +26,6 @@ beforeEach(function () {
     ];
 });
 
-
 it('accepts an array of options', function () {
     Prompt::fake([Key::RIGHT, Key::RIGHT, Key::ENTER]);
 
@@ -128,8 +127,8 @@ it('accepts a scroll value and enforces the minimum', function () {
     Prompt::assertStrippedOutputDoesntContain('line 6');
 });
 
-it('scrolls the content', function() {
-    Prompt::fake([Key:: DOWN, Key::ENTER]);
+it('scrolls the content', function () {
+    Prompt::fake([Key::DOWN, Key::ENTER]);
 
     $result = tabbedscrollableselect(
         label: 'This content should display the 6th line.',


### PR DESCRIPTION
This is a temporary solution to https://github.com/laravel/prompts/pull/154 having been closed.

That PR was a 'compatibility' PR to enable easy integration of the `AsyncPrompt`, `PatchedPrompt` will act as a 'shim' until I'm able to convince Taylor to approve my PR.

The whole point of this shim is to extract the looping mechanisms into separate functions that can be overridden in implementing classes, enabling the easy use of a `ReactPHP` event loop.

Also includes a bunch of code styling.