### PR TITLE
Add fileselector prompt

### DIFF
--- a/Docs/fileselector.md
+++ b/Docs/fileselector.md
@@ -1,0 +1,85 @@
+# Fileselector
+
+The `fileselector` function provides assistance in entering file paths `quickly` and `accurately` in interactive mode.
+
+https://github.com/laravel/prompts/assets/19181121/03c6f46d-a19d-4de0-af71-66b65c33e499
+
+## Basic Usage
+
+The `fileselector` function can be used to provide auto-completion for possible choices.
+
+The user can still provide any answer, regardless of the auto-completion hints:
+
+```php
+use function ArtisanBuild\CommunityPrompts\fileselector;
+
+$file2import = fileselector('Select a file to import.');
+```
+
+This function lists the entries in the directory on the local file system that matches the input, as the options for suggest.
+
+The user can automatically complete the input by pressing `TAB` on the selected option, then continue to input.
+The user can finish input by pressing `Enter`.
+
+You may also include placeholder text, a default value, and an informational hint:
+
+```php
+$file2import = fileselector(
+    label: 'Select a file to import.',
+    placeholder: 'E.g. ./vendor/autoload.php',
+    default: '',
+    hint: 'Input the file path.'
+);
+```
+
+## Required Values
+
+If you require a value to be entered, you may pass the `required` argument:
+
+```php
+$file2import = fileselector(
+    label: 'Select a file to import.',
+    required: true
+);
+```
+
+If you would like to customize the validation message, you may also pass a string:
+
+```php
+$file2import = fileselector(
+    label: 'Select a file to import.',
+    required: 'File path is required.'
+);
+```
+
+## Additional Validation
+
+If you would like to perform additional validation logic, you may pass a closure to the `validate` argument:
+
+```php
+$file2import = fileselector(
+    label: 'Select a file to import.',
+    validate: fn (string $value) => match (true) {
+        !is_readable($value) => 'Cannot read the file.',
+        default => null
+    }
+);
+```
+
+The closure will receive the value that has been entered and may return an error message, or `null` if the validation passes.
+
+## Filtering by File Extensions
+
+Finally, you can filter the options by passing the lists of file extensions to the parameter `extensions`.
+
+```php
+$file2import = fileselector(
+    label: 'Select a file to import.',
+    extensions: [
+        '.json',
+        '.php',
+    ],
+);
+```
+
+If the parameter `extensions` is specified, the path and directories whose path ends match one of the extensions array elements are returned as options.

--- a/playground/fileselector.php
+++ b/playground/fileselector.php
@@ -1,0 +1,23 @@
+<?php
+
+use function ArtisanBuild\CommunityPrompts\fileselector;
+
+require __DIR__.'/../vendor/autoload.php';
+
+$file2import = fileselector(
+    label: 'Select a file to import.',
+    placeholder: 'E.g. ./vendor/autoload.php',
+    validate: fn (string $value) => match (true) {
+        !is_readable($value) => 'Cannot read the file.',
+        default => null,
+    },
+    hint: 'Input the file path.',
+    extensions: [
+        '.json',
+        '.php',
+    ],
+);
+
+var_dump($file2import);
+
+echo str_repeat(PHP_EOL, 1);

--- a/src/FileSelector.php
+++ b/src/FileSelector.php
@@ -1,0 +1,224 @@
+<?php
+
+namespace ArtisanBuild\CommunityPrompts;
+
+use Closure;
+use Illuminate\Support\Collection;
+use Laravel\Prompts\Key;
+use Laravel\Prompts\Prompt;
+use ArtisanBuild\CommunityPrompts\Themes\Default\FileSelectorRenderer;
+
+class FileSelector extends Prompt
+{
+    use \Laravel\Prompts\Concerns\Scrolling;
+    use \Laravel\Prompts\Concerns\Truncation;
+    use \Laravel\Prompts\Concerns\TypedValue;
+
+    /**
+     * The options for the suggest prompt.
+     *
+     * @var array<string>|Closure(string): (array<string>|Collection<int, string>)
+     */
+    public array|Closure $options;
+
+    /**
+     * The cache of matches.
+     *
+     * @var array<string>|null
+     */
+    protected ?array $matches = null;
+
+    /**
+     * Create a new SuggestPrompt instance.
+     *
+     * @param   string[]    $extensions
+     */
+    public function __construct(
+        public string $label,
+        public string $placeholder = '',
+        public string $default = '',
+        public int $scroll = 5,
+        public bool|string $required = false,
+        public mixed $validate = null,
+        public string $hint = '',
+        public array $extensions = [],
+    ) {
+        static::$themes['default'][static::class] = FileSelectorRenderer::class;
+
+        $this->options = fn (string $value) => $this->entries($value);
+
+        $this->initializeScrolling(null);
+
+        $this->on('key', fn ($key) => match ($key) {
+            Key::UP, Key::UP_ARROW, Key::CTRL_P => $this->highlightPrevious(count($this->matches()), true),
+            Key::DOWN, Key::DOWN_ARROW, Key::CTRL_N => $this->highlightNext(count($this->matches()), true),
+            Key::TAB => $this->autoComplete(),
+            Key::oneOf([Key::HOME, Key::CTRL_A], $key) => $this->highlighted !== null ? $this->highlight(0) : null,
+            Key::oneOf([Key::END, Key::CTRL_E], $key) => $this->highlighted !== null ? $this->highlight(count($this->matches()) - 1) : null,
+            Key::ENTER => $this->selectHighlighted(),
+            Key::oneOf([Key::LEFT, Key::LEFT_ARROW, Key::RIGHT, Key::RIGHT_ARROW, Key::CTRL_B, Key::CTRL_F], $key) => $this->highlighted = null,
+            default => (function () {
+                $this->highlighted = null;
+                $this->matches = null;
+                $this->firstVisible = 0;
+            })(),
+        });
+
+        $this->trackTypedValue($default, ignore: fn ($key) => Key::oneOf([Key::HOME, Key::END, Key::CTRL_A, Key::CTRL_E], $key) && $this->highlighted !== null);
+    }
+
+    /**
+     * Get the entered value with a virtual cursor.
+     */
+    public function valueWithCursor(int $maxWidth): string
+    {
+        if ($this->highlighted !== null) {
+            return $this->value() === ''
+                ? $this->dim($this->truncate($this->placeholder, $maxWidth))
+                : $this->truncate($this->value(), $maxWidth);
+        }
+
+        if ($this->value() === '') {
+            return $this->dim($this->addCursor($this->placeholder, 0, $maxWidth));
+        }
+
+        return $this->addCursor($this->value(), $this->cursorPosition, $maxWidth);
+    }
+
+    /**
+     * Get options that match the input.
+     *
+     * @return array<string>
+     */
+    public function matches(): array
+    {
+        if (is_array($this->matches)) {
+            return $this->matches;
+        }
+
+        if ($this->options instanceof Closure) {
+            $matches = ($this->options)($this->value());
+
+            return $this->matches = array_values($matches instanceof Collection ? $matches->all() : $matches);
+        }
+
+        return $this->matches = array_values(array_filter($this->options, function ($option) {
+            return str_starts_with(strtolower($option), strtolower($this->value()));
+        }));
+    }
+
+    /**
+     * The current visible matches.
+     *
+     * @return array<string>
+     */
+    public function visible(): array
+    {
+        return array_slice($this->matches(), $this->firstVisible, $this->scroll, preserve_keys: true);
+    }
+
+    /**
+     * Select the highlighted entry.
+     */
+    protected function selectHighlighted(): void
+    {
+        if ($this->highlighted === null) {
+            return;
+        }
+
+        $this->typedValue = $this->matches()[$this->highlighted];
+    }
+
+    /**
+     * Returns all entries in the directory as RecursiveDirectoryIterator
+     *
+     * @param   string  $path
+     * @return  \RecursiveDirectoryIterator|\RegexIterator|array{}
+     */
+    protected function glob(string $path)
+    {
+        if (strlen($path) === 0) {
+            return new \RecursiveDirectoryIterator('.');
+        }
+
+        if (str_ends_with($path, '/')) {
+            if (is_dir($path) && is_readable($path)) {
+                return new \RecursiveDirectoryIterator($path);
+            }
+            return [];
+        }
+
+        $dir = './';
+        $file = $path;
+        if (str_contains($path, '/')) {
+            $dir = dirname($path);
+            $file = pathinfo($path)['basename'];
+        }
+
+        // in case of non-existent path
+        if (!is_dir($dir) || !is_readable($dir)) {
+            return [];
+        }
+
+        $pattern = sprintf("/%s/", preg_quote($file));
+        return new \RegexIterator(
+            new \RecursiveDirectoryIterator($dir),
+            $pattern
+        );
+    }
+
+    /**
+     * Returns all entries in the directory as an array
+     *
+     * @param   string  $path
+     * @return  string[]
+     */
+    protected function entries(string $path): array
+    {
+        return collect(iterator_to_array($this->glob($path)))
+            ->reject(fn (string $entry) => match (true) {
+                str_ends_with($entry, '/.'), str_ends_with($entry, '/..') => true,
+                $this->isRejectable($entry) => true,
+                default => false,
+            })
+            ->map(
+                fn (string $entry) => is_dir($entry)
+                    ? str_replace('//', '/', $entry . '/')
+                    : str_replace('//', '/', $entry)
+            )
+            ->sort()
+            ->all();
+    }
+
+    /**
+     * Ditermines whether the entry should be rejected
+     *
+     * @param   string  $entry
+     */
+    private function isRejectable(string $entry): bool
+    {
+        if (is_dir($entry)) {
+            return false;
+        }
+        if (count($this->extensions) === 0) {
+            return false;
+        }
+        foreach ($this->extensions as $extension) {
+            if (str_ends_with($entry, $extension)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * automatically complete the text input
+     */
+    protected function autoComplete(): void
+    {
+        $this->selectHighlighted();
+        $this->cursorPosition = strlen($this->value());
+        $this->emit('key', Key::SPACE);
+        $this->emit('key', Key::BACKSPACE);
+    }
+}

--- a/src/Themes/Default/FileSelectorRenderer.php
+++ b/src/Themes/Default/FileSelectorRenderer.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace ArtisanBuild\CommunityPrompts\Themes\Default;
+
+use ArtisanBuild\CommunityPrompts\FileSelector;
+use Laravel\Prompts\Themes\Contracts\Scrolling;
+use Laravel\Prompts\Themes\Default\Renderer;
+
+class FileSelectorRenderer extends Renderer implements Scrolling
+{
+    use \Laravel\Prompts\Themes\Default\Concerns\DrawsBoxes;
+    use \Laravel\Prompts\Themes\Default\Concerns\DrawsScrollbars;
+
+    /**
+     * Render the fileselector prompt.
+     */
+    public function __invoke(FileSelector $prompt): string
+    {
+        $maxWidth = $prompt->terminal()->cols() - 6;
+
+        return match ($prompt->state) {
+            'submit' => $this
+                ->box(
+                    $this->dim($this->truncate($prompt->label, $prompt->terminal()->cols() - 6)),
+                    $this->truncate($prompt->value(), $maxWidth),
+                ),
+
+            'cancel' => $this
+                ->box(
+                    $this->dim($this->truncate($prompt->label, $prompt->terminal()->cols() - 6)),
+                    $this->strikethrough($this->dim($this->truncate($prompt->value() ?: $prompt->placeholder, $maxWidth))),
+                    color: 'red',
+                )
+                ->error($prompt->cancelMessage),
+
+            'error' => $this
+                ->box(
+                    $this->truncate($prompt->label, $prompt->terminal()->cols() - 6),
+                    $this->valueWithCursorAndArrow($prompt, $maxWidth),
+                    $this->renderOptions($prompt),
+                    color: 'yellow',
+                )
+                ->warning($this->truncate($prompt->error, $prompt->terminal()->cols() - 5)),
+
+            default => $this
+                ->box(
+                    $this->cyan($this->truncate($prompt->label, $prompt->terminal()->cols() - 6)),
+                    $this->valueWithCursorAndArrow($prompt, $maxWidth),
+                    $this->renderOptions($prompt),
+                )
+                ->when(
+                    $prompt->hint,
+                    fn () => $this->hint($prompt->hint),
+                    fn () => $this->newLine() // Space for errors
+                )
+                ->spaceForDropdown($prompt),
+        };
+    }
+
+    /**
+     * Render the value with the cursor and an arrow.
+     */
+    protected function valueWithCursorAndArrow(FileSelector $prompt, int $maxWidth): string
+    {
+        if ($prompt->highlighted !== null || $prompt->value() !== '' || count($prompt->matches()) === 0) {
+            return $prompt->valueWithCursor($maxWidth);
+        }
+
+        return preg_replace(
+            '/\s$/',
+            $this->cyan('⌄'),
+            $this->pad($prompt->valueWithCursor($maxWidth - 1).'  ', min($this->longest($prompt->matches(), padding: 2), $maxWidth))
+        );
+    }
+
+    /**
+     * Render a spacer to prevent jumping when the suggestions are displayed.
+     */
+    protected function spaceForDropdown(FileSelector $prompt): self
+    {
+        if ($prompt->value() === '' && $prompt->highlighted === null) {
+            $this->newLine(min(
+                count($prompt->matches()),
+                $prompt->scroll,
+                $prompt->terminal()->lines() - 7
+            ) + 1);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Render the options.
+     */
+    protected function renderOptions(FileSelector $prompt): string
+    {
+        if (empty($prompt->matches()) || ($prompt->value() === '' && $prompt->highlighted === null)) {
+            return '';
+        }
+
+        return $this->scrollbar(
+            collect($prompt->visible())
+                ->map(fn ($label) => $this->truncate($label, $prompt->terminal()->cols() - 10))
+                ->map(fn ($label, $key) => $prompt->highlighted === $key
+                    ? "{$this->cyan('›')} {$label}  "
+                    : "  {$this->dim($label)}  "
+                ),
+            $prompt->firstVisible,
+            $prompt->scroll,
+            count($prompt->matches()),
+            min($this->longest($prompt->matches(), padding: 4), $prompt->terminal()->cols() - 6),
+            $prompt->state === 'cancel' ? 'dim' : 'cyan'
+        )->implode(PHP_EOL);
+    }
+
+    /**
+     * The number of lines to reserve outside of the scrollable area.
+     */
+    public function reservedLines(): int
+    {
+        return 7;
+    }
+}

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -17,3 +17,13 @@ function tabbedscrollableselect(string $label, array|Collection $options, int|Cl
 {
     return (new TabbedScrollableSelectPrompt(...func_get_args()))->prompt();
 }
+
+/**
+ * Prompt the user for text input with auto-completion of filepath.
+ *
+ * @param   array<string>   $extensions
+ */
+function fileselector(string $label, string $placeholder = '', string $default = '', int $scroll = 5, bool|string $required = false, mixed $validate = null, string $hint = '', array $extensions = []): string
+{
+    return (new FileSelector(...func_get_args()))->prompt();
+}

--- a/tests/Feature/FileSelectorTest.php
+++ b/tests/Feature/FileSelectorTest.php
@@ -1,0 +1,149 @@
+<?php
+
+use Laravel\Prompts\Key;
+use Laravel\Prompts\Exceptions\NonInteractiveValidationException;
+use Laravel\Prompts\Prompt;
+use ArtisanBuild\CommunityPrompts\FileSelector;
+
+use function ArtisanBuild\CommunityPrompts\fileselector;
+
+it('accepts any input', function () {
+    Prompt::fake(['B', 'l', 'a', 'c', 'k', Key::ENTER]);
+
+    $result = fileselector('What is your favorite color?');
+
+    expect($result)->toBe('Black');
+});
+
+it('completes the input using the tab key', function () {
+    Prompt::fake(['v', Key::DOWN, Key::TAB, Key::ENTER]);
+
+    $result = fileselector('Select a file.');
+
+    expect($result)->toBe('./vendor/');
+});
+
+it('completes the input using the arrow keys', function () {
+    Prompt::fake(['.', 'g', Key::DOWN, Key::DOWN, Key::UP, Key::ENTER]);
+
+    $result = fileselector('Select a file.');
+
+    expect($result)->toBe('./.git/');
+});
+
+it('supports the home key while navigating options', function () {
+    Prompt::fake([Key::DOWN, Key::DOWN, Key::DOWN, Key::HOME[0], Key::ENTER]);
+
+    $result = fileselector('Select a file.');
+
+    expect($result)->toBe('./.editorconfig');
+});
+
+it('supports the end key while navigating options', function () {
+    Prompt::fake([Key::DOWN, Key::END[0], Key::ENTER]);
+
+    $result = fileselector('What is your favorite color?');
+
+    expect($result)->toBe('./vendor/');
+});
+
+it('validates', function () {
+    Prompt::fake([Key::ENTER, 'X', Key::ENTER]);
+
+    $result = fileselector(
+        label: 'Select a file.',
+        validate: fn ($value) => empty($value) ? 'Please select a file.' : null,
+    );
+
+    expect($result)->toBe('X');
+
+    Prompt::assertOutputContains('Please select a file.');
+});
+
+it('can fall back', function () {
+    Prompt::fallbackWhen(true);
+
+    FileSelector::fallbackUsing(function (FileSelector $prompt) {
+        expect($prompt->label)->toBe('Select a file.');
+
+        return 'result';
+    });
+
+    $result = fileselector('Select a file.');
+
+    expect($result)->toBe('result');
+});
+
+it('support emacs style key binding', function () {
+    Prompt::fake(['.', 'g', Key::CTRL_N, Key::CTRL_N, Key::CTRL_N, Key::CTRL_P, Key::ENTER]);
+
+    $result = fileselector('Select a file.');
+
+    expect($result)->toBe('./.gitattributes');
+});
+
+it('returns an empty string when non-interactive', function () {
+    Prompt::interactive(false);
+
+    $result = fileselector('What is your favorite color?');
+
+    expect($result)->toBe('');
+});
+
+it('returns the default value when non-interactive', function () {
+    Prompt::interactive(false);
+
+    $result = fileselector('What is your favorite color?', default: 'Yellow');
+
+    expect($result)->toBe('Yellow');
+});
+
+it('validates the default value when non-interactive', function () {
+    Prompt::interactive(false);
+
+    fileselector('Select a file.', required: true);
+})->throws(NonInteractiveValidationException::class, 'Required.');
+
+it('supports custom validation', function () {
+    Prompt::validateUsing(function (Prompt $prompt) {
+        expect($prompt)
+            ->label->toBe('Select a file.')
+            ->validate->toBe('min:2');
+
+        return $prompt->validate === 'min:2' && strlen($prompt->value()) < 2 ? 'Minimum 2 chars!' : null;
+    });
+
+    Prompt::fake(['A', Key::ENTER, 'n', 'd', 'r', 'e', 'a', Key::ENTER]);
+
+    $result = fileselector(
+        label: 'Select a file.',
+        validate: 'min:2',
+    );
+
+    expect($result)->toBe('Andrea');
+
+    Prompt::assertOutputContains('Minimum 2 chars!');
+
+    Prompt::validateUsing(fn () => null);
+});
+
+it('update dir entries after auto complete', function () {
+    Prompt::fake(['v', 'e', 'n', Key::UP, Key::TAB, 'a', 'u', Key::DOWN, Key::TAB, Key::ENTER]);
+
+    $result = fileselector('Select a file.');
+
+    expect($result)->toBe('./vendor/autoload.php');
+});
+
+it('filter dir entries with specified extensions', function () {
+    Prompt::fake(['c', 'o', 'm', 'p', 'o', 's', 'e', 'r', Key::UP, Key::ENTER]);
+
+    $result = fileselector(
+        label: 'Select a file.',
+        extensions: [
+            '.json',
+        ],
+    );
+
+    expect($result)->toBe('./composer.json');
+});


### PR DESCRIPTION
This PR adds support for file selector.

Here's a demo video, which you can play with for yourself using `php playground/fileselector.php` on this branch.

https://github.com/laravel/prompts/assets/19181121/03c6f46d-a19d-4de0-af71-66b65c33e499

### Purpose

`fileselector`  provides assistance in entering file paths `quickly` and `accurately` in interactive mode.

### Usage

```php
use function ArtisanBuild\CommunityPrompts\fileselector;

fileselector(
    label: 'Select a file to import.',
    placeholder: 'E.g. ./vendor/autoload.php',
    validate: fn (string $value) => match (true) {
        !is_readable($value) => 'Cannot read the file.',
        default => null,
    },
    hint: 'Input the file path.',
    extensions: [
        '.json',
        '.php',
    ],
);
```
This function lists the entries in the directory on the local file system that matches the input, as the options for suggest.

You can automatically complete the input like the `suggest` prompt by pressing `TAB` on the selected option, then continue to input.
Press `Enter` to finish input.
Actually this function was created from the copy of the `suggest` promt.

You can filter the options with the parameter `extensions`.
If the parameter `extensions` is specified, the path and directories whose path ends match one of the extensions array elements are returned as options.
